### PR TITLE
update baseGasPrice to 1e13

### DIFF
--- a/common/vetDisplay.c
+++ b/common/vetDisplay.c
@@ -16,7 +16,7 @@
 #include "os.h"
 #include "vetDisplay.h"
 
-static const uint8_t const BASE_GAS_PRICE[] = {0x03, 0x8D, 0x7E, 0xA4, 0xC6, 0x80, 0x00};
+static const uint8_t const BASE_GAS_PRICE[] = {0x09, 0x18, 0x4e, 0x72, 0xa0, 0x00};
 static const uint8_t const MAX_GAS_COEF[] = {0xFF};
 static const uint8_t const TICKER_VTHO[] = "VTHO ";
 


### PR DESCRIPTION
Correct the fee display issue as we have changed the base gas price. Here is the announcement tweet, https://twitter.com/vechainofficial/status/1381608086629048331.

Before:
<img width="296" alt="Screenshot 2023-03-21 at 16 49 56" src="https://user-images.githubusercontent.com/8411962/227472222-baaea3cb-18a4-4945-9cc0-5ffc8a106957.png">

After:
<img width="293" alt="Screenshot 2023-03-21 at 16 52 06" src="https://user-images.githubusercontent.com/8411962/227472297-48fb346a-5ee2-47b4-96a0-23fef58b7c4f.png">
